### PR TITLE
prefixing the url with '/' is now causing this to 404 on tokbox's end

### DIFF
--- a/lib/resources/session.js
+++ b/lib/resources/session.js
@@ -16,7 +16,7 @@ class Session extends OpenTokResource {
   getStreamClasses (sessionId) {
     const options = {
       type: 'get',
-      endpoint: `/session/${sessionId}/stream`
+      endpoint: `session/${sessionId}/stream`
     }
     const request = this.generate(options)
     return request.send()


### PR DESCRIPTION
The double-slash now causes 404's on tokbox's side